### PR TITLE
chore: update ruff to v0.13.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM alpine:3.20
 
 ENV REVIEWDOG_VERSION=v0.21.0
+ENV RUFF_VERSION=v0.13.2
 
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 
@@ -9,7 +10,8 @@ RUN apk --no-cache add git
 
 RUN wget -O - -q https://raw.githubusercontent.com/reviewdog/reviewdog/df70ed74df59de7ebfd9276afabd62ea2de4d7dd/install.sh| sh -s -- -b /usr/local/bin/ ${REVIEWDOG_VERSION}
 
-RUN apk add ruff
+RUN wget -qO- https://astral.sh/uv/install.sh | sh
+RUN /root/.local/bin/uv tool install ruff@${RUFF_VERSION}
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,9 +9,9 @@ fi
 export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"
 
 # shellcheck disable=2086
-ruff check --output-format=concise . |
+/root/.local/bin/ruff check --output-format=concise . |
 	reviewdog -efm="%f:%l:%c: %m" \
-		-name="linter-name (ruff)" \
+		-name="ruff" \
 		-reporter="${INPUT_REPORTER:-github-pr-check}" \
 		-filter-mode="${INPUT_FILTER_MODE}" \
 		-fail-level="${INPUT_FAIL_LEVEL}" \


### PR DESCRIPTION
Also changes installation method to `uv` for easy version selection.