### PR TITLE
feat: expose ruff_args input for passing extra flags to ruff

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -33,6 +33,9 @@ inputs:
       Possible values: [none,any,info,warning,error]
       Default is `none`.
     default: none
+  ruff_args:
+    description: Additional arguments to pass to ruff
+    default: ''
   reviewdog_flags:
     description: Additional reviewdog flags
     default: ''

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,7 +9,7 @@ fi
 export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"
 
 # shellcheck disable=2086
-/root/.local/bin/ruff check --output-format=concise . |
+/root/.local/bin/ruff check --output-format=concise ${INPUT_RUFF_ARGS} . |
     reviewdog -efm="%f:%l:%c: %m" \
         -name="ruff" \
         -reporter="${INPUT_REPORTER:-github-pr-check}" \


### PR DESCRIPTION
For flexibility it's useful to have this feature.