### PR TITLE
docs: remove template copyright from LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,5 @@
 MIT License
 
-Copyright (c) 2020 reviewdog developers
 Copyright (c) 2025 Nerijus Bendžiūnas
 
 Permission is hereby granted, free of charge, to any person obtaining a copy


### PR DESCRIPTION
This action is a new product, not a fork of reviewdog; the original
"reviewdog developers" copyright line was a template leftover.