### PR TITLE
docs: mention ruff in README depup section

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ jobs:
     name: runner / ruff
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - uses: benner/action-ruff@v1
         with:
           github_token: ${{ secrets.github_token }}

--- a/README.md
+++ b/README.md
@@ -56,4 +56,4 @@ keeps `v1` / `v1.2` aliases in sync.
 ### Dependencies
 
 [reviewdog/action-depup](https://github.com/reviewdog/action-depup) runs
-daily to update the reviewdog version in the Dockerfile and open a PR.
+daily to update the reviewdog and ruff versions in the Dockerfile and open a PR.

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ jobs:
 | `filter_mode` | Filter mode: `added`, `diff_context`, `file`, `nofilter` | `added` |
 | `fail_level` | Fail if issues at or above level: `none`, `any`, `info`, `warning`, `error` | `none` |
 | `reviewdog_flags` | Additional reviewdog flags | `''` |
+| `ruff_args` | Additional arguments passed to `ruff check` | `''` |
 
 ## Development
 


### PR DESCRIPTION
The depup workflow now tracks both reviewdog and ruff versions;
the documentation only mentioned reviewdog.