### PR TITLE
ci: add markdownlint config to allow long table rows

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,3 @@
+---
+MD013:
+  tables: false


### PR DESCRIPTION
Markdown tables cannot be wrapped, so MD013 line-length is disabled
for tables only; the rule stays active for prose and code blocks.