### PR TITLE
fix: quote docker tag argument in dockerimage workflow

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -14,5 +14,4 @@ jobs:
         with:
           persist-credentials: false
       - name: Build the Docker image
-        run: docker build . --file Dockerfile --tag ${{ github.repository }}:$(date
-          +%s)
+        run: docker build . --file Dockerfile --tag "${{ github.repository }}:$(date +%s)"


### PR DESCRIPTION
Unquoted \$(date +%s) subshell triggers SC2046 word-splitting warning;
quoting the full tag value prevents unexpected splitting on whitespace.