### PR TITLE
ci(workflows): solve yamllint long-line errors

### DIFF
--- a/.github/workflows/depup.yml
+++ b/.github/workflows/depup.yml
@@ -14,9 +14,11 @@ jobs:
       contents: write
       pull-requests: write
     steps:
+      # yamllint disable-line rule:line-length
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
+      # yamllint disable-line rule:line-length
       - uses: reviewdog/action-depup/with-pr@94a1aaf4e4923064019214b48a43276218af7ad5  # v1.6.4
         with:
           file: Dockerfile
@@ -29,9 +31,11 @@ jobs:
       contents: write
       pull-requests: write
     steps:
+      # yamllint disable-line rule:line-length
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
+      # yamllint disable-line rule:line-length
       - uses: reviewdog/action-depup/with-pr@94a1aaf4e4923064019214b48a43276218af7ad5  # v1.6.4
         with:
           file: Dockerfile

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -10,8 +10,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      # yamllint disable-line rule:line-length
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
       - name: Build the Docker image
-        run: docker build . --file Dockerfile --tag "${{ github.repository }}:$(date +%s)"
+        run: >-
+          docker build . --file Dockerfile
+          --tag "${{ github.repository }}:$(date +%s)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ jobs:
     permissions:
       contents: write
     steps:
+      # yamllint disable-line rule:line-length
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
@@ -23,10 +24,12 @@ jobs:
       # (bump:major,bump:minor,bump:patch)
       - id: bumpr
         if: "!startsWith(github.ref, 'refs/tags/')"
+        # yamllint disable-line rule:line-length
         uses: haya14busa/action-bumpr@78ab5a104d20896c9c9122c64221b3aecf1a8cbb  # v1.10.0
 
       # Update corresponding major and minor tag.
       # e.g. Update v1 and v1.2 when releasing v1.2.3
+      # yamllint disable-line rule:line-length
       - uses: haya14busa/action-update-semver@fb48464b2438ae82cc78237be61afb4f461265a1  # v1.2.1
         if: '!steps.bumpr.outputs.skip'
         with:
@@ -34,6 +37,7 @@ jobs:
 
       # Get tag name.
       - id: tag
+        # yamllint disable-line rule:line-length
         uses: haya14busa/action-cond@94f77f7a80cd666cb3155084e428254fea4281fd  # v1.2.1
         with:
           cond: ${{ startsWith(github.ref, 'refs/tags/') }}
@@ -45,18 +49,23 @@ jobs:
         env:
           TAG_NAME: ${{ steps.tag.outputs.value }}
           BODY: ${{ steps.bumpr.outputs.message }}
-          # This token is provided by Actions, you do not need to create your own token
+          # This token is provided by Actions, you do not need to create your
+          # own token
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh release create "${TAG_NAME}" -t "Release ${TAG_NAME/refs\/tags\//}" --notes "${BODY}"
+        run: >-
+          gh release create "${TAG_NAME}"
+          -t "Release ${TAG_NAME/refs\/tags\//}"
+          --notes "${BODY}"
   release-check:
     if: github.event.action == 'labeled'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
     steps:
+      # yamllint disable-line rule:line-length
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
       - name: Post bumpr status comment
+        # yamllint disable-line rule:line-length
         uses: haya14busa/action-bumpr@78ab5a104d20896c9c9122c64221b3aecf1a8cbb  # v1.10.0

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -11,15 +11,18 @@ jobs:
     name: runner / shellcheck
     runs-on: ubuntu-latest
     steps:
+      # yamllint disable-line rule:line-length
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
+      # yamllint disable-line rule:line-length
       - uses: haya14busa/action-cond@94f77f7a80cd666cb3155084e428254fea4281fd  # v1.2.1
         id: reporter
         with:
           cond: ${{ github.event_name == 'pull_request' }}
           if_true: github-pr-review
           if_false: github-check
+      # yamllint disable-line rule:line-length
       - uses: reviewdog/action-shellcheck@57079a832290a049f49cee90984b072c870fb7d4  # v1.29.3
         with:
           github_token: ${{ secrets.github_token }}
@@ -29,15 +32,18 @@ jobs:
     name: runner / hadolint
     runs-on: ubuntu-latest
     steps:
+      # yamllint disable-line rule:line-length
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
+      # yamllint disable-line rule:line-length
       - uses: haya14busa/action-cond@94f77f7a80cd666cb3155084e428254fea4281fd  # v1.2.1
         id: reporter
         with:
           cond: ${{ github.event_name == 'pull_request' }}
           if_true: github-pr-review
           if_false: github-check
+      # yamllint disable-line rule:line-length
       - uses: reviewdog/action-hadolint@fc7ee4a9f71e521bc43e370819247b70e5327540  # v1.50.2
         with:
           github_token: ${{ secrets.github_token }}
@@ -47,9 +53,11 @@ jobs:
     name: runner / misspell
     runs-on: ubuntu-latest
     steps:
+      # yamllint disable-line rule:line-length
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
+      # yamllint disable-line rule:line-length
       - uses: reviewdog/action-misspell@9daa94af4357dddb6fd3775de806bc0a8e98d3e4  # v1.26.3
         with:
           github_token: ${{ secrets.github_token }}
@@ -60,9 +68,11 @@ jobs:
     name: runner / alex
     runs-on: ubuntu-latest
     steps:
+      # yamllint disable-line rule:line-length
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
+      # yamllint disable-line rule:line-length
       - uses: reviewdog/action-alex@d6230365b9cb2b2d515f85a1713aca7d11862f60  # v1.15.4
         with:
           github_token: ${{ secrets.github_token }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,7 @@ jobs:
     name: runner / ruff (github-check)
     runs-on: ubuntu-latest
     steps:
+      # yamllint disable-line rule:line-length
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
@@ -24,6 +25,7 @@ jobs:
     name: runner / ruff (github-pr-check)
     runs-on: ubuntu-latest
     steps:
+      # yamllint disable-line rule:line-length
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
@@ -38,6 +40,7 @@ jobs:
     name: runner / ruff (github-pr-review)
     runs-on: ubuntu-latest
     steps:
+      # yamllint disable-line rule:line-length
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false


### PR DESCRIPTION
<!-- PR-IT:begin -->
SHA-pinned action refs can't be shortened, so they carry a per-line
yamllint directive; breakable run commands fold with >- instead. This
keeps later pin bumps from re-triggering line-length noise.
<!-- PR-IT:end -->