### PR TITLE
ci(release): generate release notes with git-cliff

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # ratchet:actions/checkout@v7.0.0
         with:
           persist-credentials: false
+          fetch-depth: 0
 
       # Bump version on merging Pull Requests with specific labels.
       # (bump:major,bump:minor,bump:patch)
@@ -44,11 +45,19 @@ jobs:
           if_true: ${{ github.ref }}
           if_false: ${{ steps.bumpr.outputs.next_version }}
 
+      - id: changelog
+        if: steps.tag.outputs.value != ''
+        # yamllint disable-line rule:line-length
+        uses: orhun/git-cliff-action@f50e11560dce63f7c33227798f90b924471a88b5  # ratchet:orhun/git-cliff-action@v4.8.0
+        with:
+          config: cliff.toml
+          args: --latest --strip all
+
       # Create release
       - if: steps.tag.outputs.value != ''
         env:
           TAG_NAME: ${{ steps.tag.outputs.value }}
-          BODY: ${{ steps.bumpr.outputs.message }}
+          BODY: ${{ steps.changelog.outputs.content }}
           # This token is provided by Actions, you do not need to create your
           # own token
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,31 @@
+[changelog]
+header = ""
+body = """{% for group, commits in commits | group_by(attribute="group") %}### {{ group | upper_first }}
+{% for message, dupes in commits | group_by(attribute="message") %}- {{ message | upper_first }}
+{% endfor %}
+{% endfor %}"""
+trim = true
+footer = ""
+
+[git]
+conventional_commits = true
+filter_unconventional = true
+split_commits = false
+commit_preprocessors = [
+  { pattern = '(update [^\s]+) to [0-9][^\s]*', replace = "$1" },
+]
+commit_parsers = [
+  { message = "^feat", group = "Features" },
+  { message = "^fix", group = "Bug Fixes" },
+  { message = "^perf", group = "Performance" },
+  { message = "^docs", group = "Documentation" },
+  { message = "^chore\\(deps\\)", group = "Dependencies" },
+  { message = "^ci", group = "CI" },
+  { message = "^refactor", group = "Refactor" },
+  { message = "^test", group = "Testing" },
+  { message = "^chore", group = "Miscellaneous" },
+  { message = ".*", group = "Other" },
+]
+filter_commits = false
+tag_pattern = "^v[0-9]+\\.[0-9]+\\.[0-9]+$"
+sort_commits = "oldest"


### PR DESCRIPTION
<!-- PR-IT:begin -->
bumpr's message is only the triggering PR; cliff builds a grouped
changelog from Conventional Commits and collapses dependency bumps.
<!-- PR-IT:end -->