### PR TITLE
ci: strip ratchet comments to bare versions in all workflows

### DIFF
--- a/.github/workflows/depup.yml
+++ b/.github/workflows/depup.yml
@@ -15,11 +15,11 @@ jobs:
       pull-requests: write
     steps:
       # yamllint disable-line rule:line-length
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # ratchet:actions/checkout@v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           persist-credentials: false
       # yamllint disable-line rule:line-length
-      - uses: reviewdog/action-depup/with-pr@94a1aaf4e4923064019214b48a43276218af7ad5  # ratchet:reviewdog/action-depup/with-pr@v1.6.4
+      - uses: reviewdog/action-depup/with-pr@94a1aaf4e4923064019214b48a43276218af7ad5  # v1.6.4
         with:
           file: Dockerfile
           version_name: REVIEWDOG_VERSION
@@ -32,11 +32,11 @@ jobs:
       pull-requests: write
     steps:
       # yamllint disable-line rule:line-length
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # ratchet:actions/checkout@v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           persist-credentials: false
       # yamllint disable-line rule:line-length
-      - uses: reviewdog/action-depup/with-pr@94a1aaf4e4923064019214b48a43276218af7ad5  # ratchet:reviewdog/action-depup/with-pr@v1.6.4
+      - uses: reviewdog/action-depup/with-pr@94a1aaf4e4923064019214b48a43276218af7ad5  # v1.6.4
         with:
           file: Dockerfile
           version_name: RUFF_VERSION

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # yamllint disable-line rule:line-length
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # ratchet:actions/checkout@v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           persist-credentials: false
       - name: Build the Docker image

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -12,18 +12,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # yamllint disable-line rule:line-length
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # ratchet:actions/checkout@v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           persist-credentials: false
       # yamllint disable-line rule:line-length
-      - uses: haya14busa/action-cond@94f77f7a80cd666cb3155084e428254fea4281fd  # ratchet:haya14busa/action-cond@v1.2.1
+      - uses: haya14busa/action-cond@94f77f7a80cd666cb3155084e428254fea4281fd  # v1.2.1
         id: reporter
         with:
           cond: ${{ github.event_name == 'pull_request' }}
           if_true: github-pr-review
           if_false: github-check
       # yamllint disable-line rule:line-length
-      - uses: reviewdog/action-shellcheck@4c07458293ac342d477251099501a718ae5ef86e  # ratchet:reviewdog/action-shellcheck@v1.32.0
+      - uses: reviewdog/action-shellcheck@4c07458293ac342d477251099501a718ae5ef86e  # v1.32.0
         with:
           github_token: ${{ secrets.github_token }}
           reporter: ${{ steps.reporter.outputs.value }}
@@ -33,18 +33,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # yamllint disable-line rule:line-length
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # ratchet:actions/checkout@v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           persist-credentials: false
       # yamllint disable-line rule:line-length
-      - uses: haya14busa/action-cond@94f77f7a80cd666cb3155084e428254fea4281fd  # ratchet:haya14busa/action-cond@v1.2.1
+      - uses: haya14busa/action-cond@94f77f7a80cd666cb3155084e428254fea4281fd  # v1.2.1
         id: reporter
         with:
           cond: ${{ github.event_name == 'pull_request' }}
           if_true: github-pr-review
           if_false: github-check
       # yamllint disable-line rule:line-length
-      - uses: reviewdog/action-hadolint@921946a7ebaaf08ac72607bad67209f4e52b5407  # ratchet:reviewdog/action-hadolint@v1.50.5
+      - uses: reviewdog/action-hadolint@921946a7ebaaf08ac72607bad67209f4e52b5407  # v1.50.5
         with:
           github_token: ${{ secrets.github_token }}
           reporter: ${{ steps.reporter.outputs.value }}
@@ -54,11 +54,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # yamllint disable-line rule:line-length
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # ratchet:actions/checkout@v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           persist-credentials: false
       # yamllint disable-line rule:line-length
-      - uses: reviewdog/action-misspell@d6429416b12b09b4e2768307d53bef58d172e962  # ratchet:reviewdog/action-misspell@v1.27.0
+      - uses: reviewdog/action-misspell@d6429416b12b09b4e2768307d53bef58d172e962  # v1.27.0
         with:
           github_token: ${{ secrets.github_token }}
           reporter: github-check
@@ -69,11 +69,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # yamllint disable-line rule:line-length
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # ratchet:actions/checkout@v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           persist-credentials: false
       # yamllint disable-line rule:line-length
-      - uses: reviewdog/action-alex@b6673b547eeb6d430c87ef02dc3524bdf34e324d  # ratchet:reviewdog/action-alex@v1.16.1
+      - uses: reviewdog/action-alex@b6673b547eeb6d430c87ef02dc3524bdf34e324d  # v1.16.1
         with:
           github_token: ${{ secrets.github_token }}
           reporter: github-check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # yamllint disable-line rule:line-length
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # ratchet:actions/checkout@v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           persist-credentials: false
       - uses: ./
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # yamllint disable-line rule:line-length
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # ratchet:actions/checkout@v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           persist-credentials: false
       - uses: ./
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # yamllint disable-line rule:line-length
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # ratchet:actions/checkout@v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           persist-credentials: false
       - uses: ./


### PR DESCRIPTION
<!-- PR-IT:begin -->
zizmor flags resolvable # ratchet: references as untrustworthy but only
runs on files a commit touches, so these were latent findings waiting
for the next edit. Completes the cleanup release.yml already got.
<!-- PR-IT:end -->